### PR TITLE
Add optimization parameters

### DIFF
--- a/include/roboptim/core/plugin/eigen/eigen-levenberg-marquardt.hh
+++ b/include/roboptim/core/plugin/eigen/eigen-levenberg-marquardt.hh
@@ -112,6 +112,7 @@ namespace roboptim {
       /// \brief Initialize the solver.
       /// \param problem problem.
       void initialize (const problem_t& problem);
+      void initializeParameters();
 
     private:
       /// \brief Base cost function.

--- a/src/eigen-levenberg-marquardt.cc
+++ b/src/eigen-levenberg-marquardt.cc
@@ -28,6 +28,7 @@
 #include <roboptim/core/sum-of-c1-squares.hh>
 
 #include <roboptim/core/plugin/eigen/eigen-levenberg-marquardt.hh>
+#include <roboptim/core/plugin/eigen/config.hh>
 
 #include <unsupported/Eigen/NonLinearOptimization>
 
@@ -278,27 +279,27 @@ extern "C"
   using namespace roboptim::eigen;
   typedef SolverWithJacobian::parent_t solver_t;
 
-  ROBOPTIM_DLLEXPORT unsigned getSizeOfProblem ();
-  ROBOPTIM_DLLEXPORT const char* getTypeIdOfConstraintsList ();
-  ROBOPTIM_DLLEXPORT solver_t* create (const SolverWithJacobian::problem_t& pb);
-  ROBOPTIM_DLLEXPORT void destroy (solver_t* p);
+  ROBOPTIM_CORE_PLUGIN_EIGEN_DLLEXPORT unsigned getSizeOfProblem ();
+  ROBOPTIM_CORE_PLUGIN_EIGEN_DLLEXPORT const char* getTypeIdOfConstraintsList ();
+  ROBOPTIM_CORE_PLUGIN_EIGEN_DLLEXPORT solver_t* create (const SolverWithJacobian::problem_t& pb);
+  ROBOPTIM_CORE_PLUGIN_EIGEN_DLLEXPORT void destroy (solver_t* p);
 
-  ROBOPTIM_DLLEXPORT unsigned getSizeOfProblem ()
+  ROBOPTIM_CORE_PLUGIN_EIGEN_DLLEXPORT unsigned getSizeOfProblem ()
   {
     return sizeof (solver_t::problem_t);
   }
 
-  ROBOPTIM_DLLEXPORT const char* getTypeIdOfConstraintsList ()
+  ROBOPTIM_CORE_PLUGIN_EIGEN_DLLEXPORT const char* getTypeIdOfConstraintsList ()
   {
     return typeid (solver_t::problem_t::constraintsList_t).name ();
   }
 
-  ROBOPTIM_DLLEXPORT solver_t* create (const SolverWithJacobian::problem_t& pb)
+  ROBOPTIM_CORE_PLUGIN_EIGEN_DLLEXPORT solver_t* create (const SolverWithJacobian::problem_t& pb)
   {
     return new SolverWithJacobian (pb);
   }
 
-  ROBOPTIM_DLLEXPORT void destroy (solver_t* p)
+  ROBOPTIM_CORE_PLUGIN_EIGEN_DLLEXPORT void destroy (solver_t* p)
   {
     delete p;
   }


### PR DESCRIPTION
This PR adds optimization parameters, as supported by Eigen 3.2.0  (Ubuntu 14.04)

Warning: There seems to be a change of interface for Eigen 3.2.9  (optimization parameters accessed through setters instead of directly by a public variable).

I'm not sure which version of Eigen is intended to be supported?